### PR TITLE
Fix incorrect references in some shoji screen recipes

### DIFF
--- a/src/main/resources/data/eastwardjourneys/recipes/dark_shoji_screen_grided_heavy.json
+++ b/src/main/resources/data/eastwardjourneys/recipes/dark_shoji_screen_grided_heavy.json
@@ -14,7 +14,7 @@
     }
   },
   "result": {
-    "item": "eastwardjourneys:dark_shoji_screen_grided",
+    "item": "eastwardjourneys:dark_shoji_screen_grided_heavy",
     "count": 6
   }
 }

--- a/src/main/resources/data/eastwardjourneys/recipes/shoji_screen_grided.json
+++ b/src/main/resources/data/eastwardjourneys/recipes/shoji_screen_grided.json
@@ -14,7 +14,7 @@
     }
   },
   "result": {
-    "item": "eastwardjourneys:shoji_screen",
+    "item": "eastwardjourneys:shoji_screen_grided",
     "count": 6
   }
 }

--- a/src/main/resources/data/eastwardjourneys/recipes/shoji_screen_grided_heavy.json
+++ b/src/main/resources/data/eastwardjourneys/recipes/shoji_screen_grided_heavy.json
@@ -14,7 +14,7 @@
     }
   },
   "result": {
-    "item": "eastwardjourneys:shoji_screen",
+    "item": "eastwardjourneys:shoji_screen_grided_heavy",
     "count": 6
   }
 }

--- a/src/main/resources/data/eastwardjourneys/recipes/small_dark_shoji_screen.json
+++ b/src/main/resources/data/eastwardjourneys/recipes/small_dark_shoji_screen.json
@@ -13,7 +13,7 @@
     }
   },
   "result": {
-    "item": "eastwardjourneys:shoji_screen",
+    "item": "eastwardjourneys:small_dark_shoji_screen",
     "count": 6
   }
 }

--- a/src/main/resources/data/eastwardjourneys/recipes/small_shoji_screen.json
+++ b/src/main/resources/data/eastwardjourneys/recipes/small_shoji_screen.json
@@ -13,7 +13,7 @@
     }
   },
   "result": {
-    "item": "eastwardjourneys:shoji_screen",
+    "item": "eastwardjourneys:small_shoji_screen",
     "count": 6
   }
 }


### PR DESCRIPTION
Fixes:
- Some recipes have been fixed to allow shoji screen variants to be crafted in survival. These include:
    - Dark shoji screen (grided heavy bottom)
    - Shoji screen (grided)
    - Shoji screen (grided heavy bottom)
    - Small dark shoji screen
    - Small shoji screen